### PR TITLE
Add tag filter with multi select

### DIFF
--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -6,8 +6,12 @@ import { SITE_TITLE, SITE_DESCRIPTION } from '../../consts';
 import { getCollection } from 'astro:content';
 
 const collection = await getCollection('content');
+const nodes = collection
+  .filter(node => node.data)
+  .sort((a, b) => (b.data.date?.valueOf() ?? 0) - (a.data.date?.valueOf() ?? 0));
+
 const tagSet = new Set<string>();
-collection.forEach(node => node.data.filetags?.forEach(tag => tagSet.add(tag)));
+nodes.forEach(node => node.data.filetags?.forEach(tag => tagSet.add(tag)));
 const tags = Array.from(tagSet).sort();
 ---
 <!doctype html>
@@ -20,14 +24,50 @@ const tags = Array.from(tagSet).sort();
     <main id="main">
       <h1><a href="/">Tags</a></h1>
       <article>
-        <ul>
+        <fieldset id="tag-filter">
           {tags.map(tag => (
-            <li><a href={`/tags/${tag}/`}>{tag}</a></li>
+            <label>
+              <input type="checkbox" value={tag} /> {tag}
+            </label>
+          ))}
+        </fieldset>
+
+        <ul id="items">
+          {nodes.map(node => (
+            <li data-tags={(node.data.filetags ?? []).join(' ')}>
+              <a href={`/content/${node.data.slug}/`}>{node.data.title}</a>
+            </li>
           ))}
         </ul>
       </article>
       <Footer />
     </main>
     <Search />
+    <script>
+      const filter = document.getElementById('tag-filter') as HTMLFieldSetElement | null;
+      const items = Array.from(document.querySelectorAll<HTMLLIElement>('#items li'));
+
+      function apply() {
+        const active = Array.from(filter?.querySelectorAll<HTMLInputElement>('input:checked') ?? []).map(i => i.value);
+        items.forEach(li => {
+          const tags = li.dataset.tags ? li.dataset.tags.split(' ') : [];
+          li.hidden = active.length > 0 && !active.every(t => tags.includes(t));
+        });
+        const query = active.length ? `?tags=${active.join(',')}` : '';
+        history.replaceState(null, '', query);
+      }
+
+      filter?.addEventListener('change', apply);
+
+      const params = new URLSearchParams(location.search);
+      const initial = params.get('tags');
+      if (initial) {
+        initial.split(',').forEach(tag => {
+          const input = filter?.querySelector<HTMLInputElement>(`input[value="${tag}"]`);
+          if (input) input.checked = true;
+        });
+        apply();
+      }
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- allow tag page to filter posts by several tags
- show a checkbox list of tags
- update results as tags are selected

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684faea723e88333ab080dc6653ba74e