### PR TITLE
Add search box and remove footer tag nav

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,7 +1,4 @@
 <footer>
-  <div class="footer-nav">
-    <a href="/tags/">Tags</a>
-  </div>
   <p>Contact & Links:</p>
   <div class="contact-links">
     <a href="https://github.com/mayphus" target="_blank">GitHub</a>

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -23,6 +23,7 @@ const tags = Array.from(tagSet).sort();
     <a href="#main" class="skip-link">Skip to main content</a>
     <main id="main">
       <h1><a href="/">Tags</a></h1>
+      <input id="search-box" type="text" placeholder="Search posts" aria-label="Search posts" />
       <article>
         <fieldset id="tag-filter">
           {tags.map(tag => (
@@ -46,18 +47,23 @@ const tags = Array.from(tagSet).sort();
     <script>
       const filter = document.getElementById('tag-filter') as HTMLFieldSetElement | null;
       const items = Array.from(document.querySelectorAll<HTMLLIElement>('#items li'));
+      const searchInput = document.getElementById('search-box') as HTMLInputElement | null;
 
       function apply() {
         const active = Array.from(filter?.querySelectorAll<HTMLInputElement>('input:checked') ?? []).map(i => i.value);
         items.forEach(li => {
           const tags = li.dataset.tags ? li.dataset.tags.split(' ') : [];
-          li.hidden = active.length > 0 && !active.every(t => tags.includes(t));
+          const text = li.textContent?.toLowerCase() ?? '';
+          const matchesTags = active.length === 0 || active.every(t => tags.includes(t));
+          const matchesSearch = !searchInput?.value || text.includes(searchInput.value.toLowerCase());
+          li.hidden = !(matchesTags && matchesSearch);
         });
         const query = active.length ? `?tags=${active.join(',')}` : '';
         history.replaceState(null, '', query);
       }
 
       filter?.addEventListener('change', apply);
+      searchInput?.addEventListener("input", apply);
 
       const params = new URLSearchParams(location.search);
       const initial = params.get('tags');


### PR DESCRIPTION
## Summary
- remove the "Tags" navigation link from the site footer
- add an inline search box to the tag index page
- filter tag list items by text input

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684fb43a964083339798cd383d57ee62