### PR TITLE
Add responsive TOC for long pages

### DIFF
--- a/src/layouts/NodeLayout.astro
+++ b/src/layouts/NodeLayout.astro
@@ -16,15 +16,47 @@ const { title = 'Untitled' } = Astro.props;
 		<BaseHead title={title} description="mayphus tang's digital workshop" />
 	</head>
 
-	<body>
-		<a href="#main" class="skip-link">Skip to main content</a>
-		<main id="main">
-			<article>
-				<h1><a href="/">{title}</a></h1>
-				<slot />
-			</article>
-			<Footer />
-		</main>
-		<Search />
-	</body>
+        <body>
+                <a href="#main" class="skip-link">Skip to main content</a>
+                <nav id="toc" class="toc"></nav>
+                <main id="main">
+                        <article>
+                                <h1><a href="/">{title}</a></h1>
+                                <slot />
+                        </article>
+                        <Footer />
+                </main>
+                <Search />
+                <script is:inline>
+                        (() => {
+                                const headings = Array.from(
+                                        document.querySelectorAll('article h2, article h3')
+                                );
+                                if (
+                                        headings.length >= 4 &&
+                                        window.matchMedia('(min-width: 1024px)').matches
+                                ) {
+                                        const toc = document.getElementById('toc');
+                                        if (!toc) return;
+                                        const list = document.createElement('ul');
+                                        headings.forEach(h => {
+                                                const text = h.textContent ?? '';
+                                                if (!h.id) {
+                                                        h.id = text
+                                                                .toLowerCase()
+                                                                .replace(/\s+/g, '-');
+                                                }
+                                                const li = document.createElement('li');
+                                                const a = document.createElement('a');
+                                                a.textContent = text;
+                                                a.href = '#' + h.id;
+                                                li.appendChild(a);
+                                                list.appendChild(li);
+                                        });
+                                        toc.appendChild(list);
+                                        document.body.classList.add('with-toc');
+                                }
+                        })();
+                </script>
+        </body>
 </html>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -769,3 +769,45 @@ article {
   margin: 0;
   padding: 0;
 }
+
+/* Table of contents - shown only on large screens */
+.toc {
+  display: none;
+  font-size: 0.9em;
+  line-height: 1.4;
+}
+
+body.with-toc {
+  padding-left: 14rem;
+}
+
+@media (min-width: 1024px) {
+  .toc {
+    display: block;
+    position: fixed;
+    left: 1.5rem;
+    top: 4rem;
+    width: 12rem;
+    max-height: calc(100vh - 6rem);
+    overflow-y: auto;
+  }
+
+  .toc ul {
+    list-style: none;
+    padding-left: 0;
+    margin: 0;
+  }
+
+  .toc li {
+    margin: 0.25rem 0;
+  }
+
+  .toc a {
+    color: #0066cc;
+    text-decoration: none;
+  }
+
+  .toc a:hover {
+    text-decoration: underline;
+  }
+}


### PR DESCRIPTION
## Summary
- create a placeholder `<nav>` for table of contents in `NodeLayout`
- build TOC from headings on large screens only
- style the TOC sidebar in global CSS

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684fec797cd88333b2dd549b346ec28f